### PR TITLE
Fix go.mod module location

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/aman-bansal/go_get_set_generator
+module github.com/Jille/go_get_set_generator
 
 go 1.13


### PR DESCRIPTION
```
$ go version
go version go1.18.5 linux/amd64

$ go install github.com/Jille/go_get_set_generator/get_set_generate@latest
go: github.com/Jille/go_get_set_generator/get_set_generate@latest: github.com/Jille/go_get_set_generator@v0.0.0-20220829152514-01c72986243e: parsing go.mod:
        module declares its path as: github.com/aman-bansal/go_get_set_generator
                but was required as: github.com/Jille/go_get_set_generator
```